### PR TITLE
[김범주]Week3

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,14 +16,18 @@
   </head>
   <body>
     <header>
-      <nav>
-        <a href="index.html">
-          <img src="./images/logo.svg" alt="홈으로 연결된 Linkbrary 로고" />
-        </a>
-        <a class="cta cta-short" href="signin.html">
-          <span>로그인</span>
-        </a>
-      </nav>
+      <div class="responsive-space">
+        <div class="space"></div>
+        <nav>
+          <a href="index.html">
+            <img src="./images/logo.svg" alt="홈으로 연결된 Linkbrary 로고" />
+          </a>
+          <a class="cta cta-short" href="signin.html">
+            <span>로그인</span>
+          </a>
+        </nav>
+        <div class="space"></div>
+      </div>
       <div class="hero-header">
         <h1 class="slogan">
           <span class="slogan-gradient background-clip-text"> 세상의 모든 정보</span>를

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta property="og:title" content="Linkbrary">
+    <meta property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요">
+    <meta property="og:image" content="https://s3-alpha-sig.figma.com/img/2080/5edd/4edb32d644767d750d576d9e6c790df2?Expires=1702857600&Signature=k8FtsVa22S~CJQkqCVO8sFstQN9UR0atgM7FoM1HzRcT2thIlAy1x4M2GUKARPJafhJpQzsIfMWs5~lbLqnsMC96cV87woOdIWWxR93SZX16ZJTW-uEIADmTc~SS2Pm-qa3Eb-xbj18Z-yXZIeWgzfDZDDZs9QCleC1XENqYn7QTpu~~c7cNcjCNjpZb3AlCr0uI-yTLht5Wb1smue4hw5BIeffjBEK-k2lZosrNk18Ae34EB82BKbxZIejixgwlaC5AJ04cvh1UlXgwnKII3GxFqJ3T3g7tjRO2Ys-5RY584vsP15iIxOZJ98-UKr2CMeFeukk2PtlLP7qBnj0oWQ__&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4">
     <title>Linkbrary</title>
     <link
       rel="stylesheet"

--- a/signin.html
+++ b/signin.html
@@ -32,11 +32,11 @@
             <label>비밀번호</label>
             <div class="password-eye">
               <input type="password" name="user-password">
-              <img src="images/eye-off.svg" alt="눈에 빗금친 아이콘" style="cursor: pointer;">
+              <img src="images/eye-off.svg" alt="눈에 빗금친 아이콘">
             </div>
           </div>
         </section>
-        <button type="button" style="cursor: pointer;">로그인</button>
+        <button type="button">로그인</button>
       </form>
       <footer>
         <span>소셜 로그인</span>

--- a/signup.html
+++ b/signup.html
@@ -32,18 +32,18 @@
             <label>비밀번호</label>
             <div class="password-eye">
               <input type="password" name="user-password">
-              <img src="images/eye-off.svg" alt="눈에 빗금친 아이콘" style="cursor: pointer;">
+              <img src="images/eye-off.svg" alt="눈에 빗금친 아이콘">
             </div>
           </div>
           <div class="password-check input">
             <label>비밀번호 확인</label>
             <div class="password-eye">
               <input type="password" name="user-password-check">
-              <img src="images/eye-off.svg" alt="눈에 빗금친 아이콘" style="cursor: pointer;">
+              <img src="images/eye-off.svg" alt="눈에 빗금친 아이콘">
             </div>
           </div>
         </section>
-        <button type="button" style="cursor: pointer;">로그인</button>
+        <button type="button">로그인</button>
       </form>
       <footer>
         <span>다른 방식으로 가입하기</span>

--- a/src/reset.css
+++ b/src/reset.css
@@ -4,6 +4,8 @@
   box-sizing: border-box;
   margin: 0;
   font-family: "Pretendard";
+  font-style: normal;
+  line-height: normal;
 }
 
 html,

--- a/src/signin.css
+++ b/src/signin.css
@@ -13,7 +13,7 @@
 body {
   display: flex;
   width: 100%;
-  padding: 238px 0px 252px 0px;
+  padding: 23.8rem 0 25.2rem 0;
   justify-content: center;
   align-items: center;
 
@@ -24,45 +24,45 @@ article {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 32px;
+  gap: 3.2rem;
 }
 
 form {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 30px;
+  gap: 3rem;
 }
 
 header {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .linkbrary-logo {
-  width: 210.583px;
-  height: 38px;
+  width: 21.0583rem;
+  height: 3.8rem;
 }
 
 .goto-signup {
   display: flex;
-  gap: 8px;
+  gap: 0.8rem;
 }
 
 .goto-signup>span {
   color: var(--black, #000);
 
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
-  line-height: 24px;
+  line-height: 2.4rem;
 }
 
 .goto-signup>a {
   color: var(--linkbrary-primary-color);
 
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 600;
   text-decoration: underline;
 }
@@ -71,21 +71,21 @@ section {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 24px;
+  gap: 2.4rem;
 }
 
 .input {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 12px;
+  gap: 1.2rem;
 }
 
 label {
   color: var(--black, #000);
 
   /* Linkbrary/body2-regular */
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 400;
 }
 
@@ -99,76 +99,76 @@ label {
 
 input {
   display: flex;
-  width: 400px;
-  padding: 18px 15px;
+  width: 40rem;
+  padding: 1.8rem 1.5rem;
   justify-content: center;
   align-items: center;
 
-  border-radius: 8px;
-  border: 1px solid var(--linkbrary-gray-20);
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--linkbrary-gray-20);
   background: var(--linkbrary-white);
 }
 
 input:focus {
-  border-radius: 8px;
-  border: 1px solid var(--linkbrary-primary-color);
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--linkbrary-primary-color);
   background: var(--linkbrary-white);
   outline: none;
 }
 
 .password-eye>img {
   position: absolute;
-  right: 15px;
-  top: 18px;
-  bottom: 18px;
+  right: 1.5rem;
+  top: 1.8rem;
+  bottom: 1.8rem;
 }
 
 button {
   display: flex;
-  width: 400px;
-  padding: 16px 20px;
+  width: 40rem;
+  padding: 1.6rem 2rem;
   justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 1rem;
   border: none;
   cursor: pointer;
 
   color: var(--grey-light, #F5F5F5);
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 600;
 
-  border-radius: 8px;
+  border-radius: 0.8rem;
   background: var(--gra-purpleblue-to-skyblue, linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%));
 }
 
 footer {
   display: flex;
-  width: 400px;
-  padding: 12px 24px;
+  width: 40rem;
+  padding: 1.2rem 2.4rem;
   justify-content: space-between;
   align-items: center;
 
-  border-radius: 8px;
-  border: 1px solid var(--linkbrary-gray-20);
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--linkbrary-gray-20);
   background: var(--linkbrary-gray-10);
 }
 
 footer>span {
   color: var(--linkbrary-gray-100);
 
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 400;
 }
 
 .icons {
   display: flex;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .google,
 .kakao {
-  width: 42px;
-  height: 42px;
+  width: 4.2rem;
+  height: 4.2rem;
   flex-shrink: 0;
 }

--- a/src/signin.css
+++ b/src/signin.css
@@ -54,9 +54,7 @@ header {
 .goto-signup>span {
   color: var(--black, #000);
 
-  font-family: Pretendard;
   font-size: 16px;
-  font-style: normal;
   font-weight: 400;
   line-height: 24px;
 }
@@ -64,11 +62,8 @@ header {
 .goto-signup>a {
   color: var(--linkbrary-primary-color);
 
-  font-family: Pretendard;
   font-size: 16px;
-  font-style: normal;
   font-weight: 600;
-  line-height: normal;
   text-decoration: underline;
 }
 
@@ -90,11 +85,8 @@ label {
   color: var(--black, #000);
 
   /* Linkbrary/body2-regular */
-  font-family: Pretendard;
   font-size: 14px;
-  font-style: normal;
   font-weight: 400;
-  line-height: normal;
 }
 
 .password-eye {
@@ -142,11 +134,8 @@ button {
   cursor: pointer;
 
   color: var(--grey-light, #F5F5F5);
-  font-family: Pretendard;
   font-size: 18px;
-  font-style: normal;
   font-weight: 600;
-  line-height: normal;
 
   border-radius: 8px;
   background: var(--gra-purpleblue-to-skyblue, linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%));
@@ -167,11 +156,8 @@ footer {
 footer>span {
   color: var(--linkbrary-gray-100);
 
-  font-family: Pretendard;
   font-size: 14px;
-  font-style: normal;
   font-weight: 400;
-  line-height: normal;
 }
 
 .icons {
@@ -183,6 +169,6 @@ footer>span {
 .google,
 .kakao {
   width: 42px;
-height: 42px;
-flex-shrink: 0;
+  height: 42px;
+  flex-shrink: 0;
 }

--- a/src/signin.css
+++ b/src/signin.css
@@ -25,6 +25,7 @@ article {
   flex-direction: column;
   align-items: center;
   gap: 3.2rem;
+  width: 100%;
 }
 
 form {
@@ -32,6 +33,7 @@ form {
   flex-direction: column;
   align-items: center;
   gap: 3rem;
+  width: 100%;
 }
 
 header {
@@ -72,6 +74,8 @@ section {
   flex-direction: column;
   align-items: flex-start;
   gap: 2.4rem;
+  max-width: 40rem;
+  width: 100%;
 }
 
 .input {
@@ -79,6 +83,7 @@ section {
   flex-direction: column;
   align-items: flex-start;
   gap: 1.2rem;
+  width: 100%;
 }
 
 label {
@@ -91,11 +96,14 @@ label {
 
 .password-eye {
   position: relative;
+  max-width: 40rem;
+  width: 100%;
 }
 
 input {
   display: flex;
-  width: 40rem;
+  max-width: 40rem;
+  width: 100%;
   padding: 1.8rem 1.5rem;
   justify-content: center;
   align-items: center;
@@ -122,7 +130,8 @@ input:focus {
 
 button {
   display: flex;
-  width: 40rem;
+  max-width: 40rem;
+  width: 100%;
   padding: 1.6rem 2rem;
   justify-content: center;
   align-items: center;
@@ -140,7 +149,8 @@ button {
 
 footer {
   display: flex;
-  width: 40rem;
+  max-width: 40rem;
+  width: 100%;
   padding: 1.2rem 2.4rem;
   justify-content: space-between;
   align-items: center;
@@ -170,25 +180,18 @@ footer>span {
   flex-shrink: 0;
 }
 
-@media (max-width: 767px) {
-  :not(a, span, img, label, .icons, .goto-signup) {
-    width: 100%;
-  }
 
+
+
+
+
+/* 모바일 크기 */
+@media (max-width: 767px) {
   body {
     background: var(--linkbrary-bg);
 
     display: inline-flex;
     padding: 12rem 3.2rem 11.9rem 3.3rem;
     flex-direction: column;
-    align-items: center;
-  }
-
-  .password-eye,
-  input,
-  button,
-  footer,
-  section {
-    max-width: 40rem;
   }
 }

--- a/src/signin.css
+++ b/src/signin.css
@@ -101,6 +101,10 @@ label {
   position: relative;
 }
 
+.password-eye img {
+  cursor: pointer;
+}
+
 input {
   display: flex;
   width: 400px;
@@ -135,6 +139,7 @@ button {
   align-items: center;
   gap: 10px;
   border: none;
+  cursor: pointer;
 
   color: var(--grey-light, #F5F5F5);
   font-family: Pretendard;

--- a/src/signin.css
+++ b/src/signin.css
@@ -93,10 +93,6 @@ label {
   position: relative;
 }
 
-.password-eye img {
-  cursor: pointer;
-}
-
 input {
   display: flex;
   width: 40rem;
@@ -121,6 +117,7 @@ input:focus {
   right: 1.5rem;
   top: 1.8rem;
   bottom: 1.8rem;
+  cursor: pointer;
 }
 
 button {
@@ -171,4 +168,27 @@ footer>span {
   width: 4.2rem;
   height: 4.2rem;
   flex-shrink: 0;
+}
+
+@media (max-width: 767px) {
+  :not(a, span, img, label, .icons, .goto-signup) {
+    width: 100%;
+  }
+
+  body {
+    background: var(--linkbrary-bg);
+
+    display: inline-flex;
+    padding: 12rem 3.2rem 11.9rem 3.3rem;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .password-eye,
+  input,
+  button,
+  footer,
+  section {
+    max-width: 40rem;
+  }
 }

--- a/src/signup.css
+++ b/src/signup.css
@@ -25,6 +25,7 @@ article {
   flex-direction: column;
   align-items: center;
   gap: 3.2rem;
+  width: 100%;
 }
 
 form {
@@ -32,6 +33,7 @@ form {
   flex-direction: column;
   align-items: center;
   gap: 3rem;
+  width: 100%;
 }
 
 header {
@@ -72,6 +74,8 @@ section {
   flex-direction: column;
   align-items: center;
   gap: 2.4rem;
+  max-width: 40rem;
+  width: 100%;
 }
 
 .input {
@@ -79,6 +83,7 @@ section {
   flex-direction: column;
   align-items: flex-start;
   gap: 1.2rem;
+  width: 100%;
 }
 
 label {
@@ -91,6 +96,8 @@ label {
 
 .password-eye {
   position: relative;
+  max-width: 40rem;
+  width: 100%;
 }
 
 .password-eye img {
@@ -99,7 +106,8 @@ label {
 
 input {
   display: flex;
-  width: 40rem;
+  max-width: 40rem;
+  width: 100%;
   padding: 1.8rem 1.5rem;
   justify-content: center;
   align-items: center;
@@ -125,7 +133,8 @@ input:focus {
 
 button {
   display: flex;
-  width: 40rem;
+  max-width: 40rem;
+  width: 100%;
   padding: 1.6rem 2rem;
   justify-content: center;
   align-items: center;
@@ -143,7 +152,8 @@ button {
 
 footer {
   display: flex;
-  width: 40rem;
+  max-width: 40rem;
+  width: 100%;
   padding: 1.2rem 2.4rem;
   justify-content: space-between;
   align-items: center;
@@ -173,25 +183,18 @@ footer>span {
   flex-shrink: 0;
 }
 
-@media (max-width: 767px) {
-  :not(a, span, img, label, .icons, .goto-signin) {
-    width: 100%;
-  }
 
+
+
+
+
+/* 모바일 크기 */
+@media (max-width: 767px) {
   body {
     background: var(--linkbrary-bg);
 
     display: inline-flex;
     padding: 12rem 3.2rem 11.9rem 3.3rem;
     flex-direction: column;
-    align-items: center;
-  }
-
-  .password-eye,
-  input,
-  button,
-  footer,
-  section {
-    max-width: 40rem;
   }
 }

--- a/src/signup.css
+++ b/src/signup.css
@@ -13,7 +13,7 @@
 body {
   display: flex;
   width: 100%;
-  padding: 238px 0px 116px 0px;
+  padding: 23.8rem 0 11.6rem 0;
   justify-content: center;
   align-items: center;
 
@@ -24,45 +24,45 @@ article {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 32px;
+  gap: 3.2rem;
 }
 
 form {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 30px;
+  gap: 3rem;
 }
 
 header {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .linkbrary-logo {
-  width: 210.583px;
-  height: 38px;
+  width: 21.0583rem;
+  height: 3.8rem;
 }
 
 .goto-signin {
   display: flex;
-  gap: 8px;
+  gap: 0.8rem;
 }
 
 .goto-signin>span {
   color: var(--black, #000);
 
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
-  line-height: 24px;
+  line-height: 2.4rem;
 }
 
 .goto-signin>a {
   color: var(--linkbrary-primary-color);
 
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 600;
   text-decoration: underline;
 }
@@ -71,21 +71,21 @@ section {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 24px;
+  gap: 2.4rem;
 }
 
 .input {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 12px;
+  gap: 1.2rem;
 }
 
 label {
   color: var(--black, #000);
 
   /* Linkbrary/body2-regular */
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 400;
 }
 
@@ -99,76 +99,76 @@ label {
 
 input {
   display: flex;
-  width: 400px;
-  padding: 18px 15px;
+  width: 40rem;
+  padding: 1.8rem 1.5rem;
   justify-content: center;
   align-items: center;
 
-  border-radius: 8px;
-  border: 1px solid var(--linkbrary-gray-20);
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--linkbrary-gray-20);
   background: var(--linkbrary-white);
 }
 
 input:focus {
-  border-radius: 8px;
-  border: 1px solid var(--linkbrary-primary-color);
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--linkbrary-primary-color);
   background: var(--linkbrary-white);
   outline: none;
 }
 
 .password-eye>img {
   position: absolute;
-  right: 15px;
-  top: 18px;
-  bottom: 18px;
+  right: 1.5rem;
+  top: 1.8rem;
+  bottom: 1.8rem;
 }
 
 button {
   display: flex;
-  width: 400px;
-  padding: 16px 20px;
+  width: 40rem;
+  padding: 1.6rem 2rem;
   justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 1rem;
   border: none;
   cursor: pointer;
 
   color: var(--grey-light, #F5F5F5);
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 600;
 
-  border-radius: 8px;
+  border-radius: 0.8rem;
   background: var(--gra-purpleblue-to-skyblue, linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%));
 }
 
 footer {
   display: flex;
-  width: 400px;
-  padding: 12px 24px;
+  width: 40rem;
+  padding: 1.2rem 2.4rem;
   justify-content: space-between;
   align-items: center;
 
-  border-radius: 8px;
-  border: 1px solid var(--linkbrary-gray-20);
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--linkbrary-gray-20);
   background: var(--linkbrary-gray-10);
 }
 
 footer>span {
   color: var(--linkbrary-gray-100);
 
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 400;
 }
 
 .icons {
   display: flex;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .google,
 .kakao {
-  width: 42px;
-  height: 42px;
+  width: 4.2rem;
+  height: 4.2rem;
   flex-shrink: 0;
 }

--- a/src/signup.css
+++ b/src/signup.css
@@ -54,9 +54,7 @@ header {
 .goto-signin>span {
   color: var(--black, #000);
 
-  font-family: Pretendard;
   font-size: 16px;
-  font-style: normal;
   font-weight: 400;
   line-height: 24px;
 }
@@ -64,11 +62,8 @@ header {
 .goto-signin>a {
   color: var(--linkbrary-primary-color);
 
-  font-family: Pretendard;
   font-size: 16px;
-  font-style: normal;
   font-weight: 600;
-  line-height: normal;
   text-decoration: underline;
 }
 
@@ -90,11 +85,8 @@ label {
   color: var(--black, #000);
 
   /* Linkbrary/body2-regular */
-  font-family: Pretendard;
   font-size: 14px;
-  font-style: normal;
   font-weight: 400;
-  line-height: normal;
 }
 
 .password-eye {
@@ -142,11 +134,8 @@ button {
   cursor: pointer;
 
   color: var(--grey-light, #F5F5F5);
-  font-family: Pretendard;
   font-size: 18px;
-  font-style: normal;
   font-weight: 600;
-  line-height: normal;
 
   border-radius: 8px;
   background: var(--gra-purpleblue-to-skyblue, linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%));
@@ -167,11 +156,8 @@ footer {
 footer>span {
   color: var(--linkbrary-gray-100);
 
-  font-family: Pretendard;
   font-size: 14px;
-  font-style: normal;
   font-weight: 400;
-  line-height: normal;
 }
 
 .icons {

--- a/src/signup.css
+++ b/src/signup.css
@@ -101,6 +101,10 @@ label {
   position: relative;
 }
 
+.password-eye img {
+  cursor: pointer;
+}
+
 input {
   display: flex;
   width: 400px;
@@ -135,6 +139,7 @@ button {
   align-items: center;
   gap: 10px;
   border: none;
+  cursor: pointer;
 
   color: var(--grey-light, #F5F5F5);
   font-family: Pretendard;

--- a/src/signup.css
+++ b/src/signup.css
@@ -70,7 +70,7 @@ header {
 section {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 2.4rem;
 }
 
@@ -171,4 +171,27 @@ footer>span {
   width: 4.2rem;
   height: 4.2rem;
   flex-shrink: 0;
+}
+
+@media (max-width: 767px) {
+  :not(a, span, img, label, .icons, .goto-signin) {
+    width: 100%;
+  }
+
+  body {
+    background: var(--linkbrary-bg);
+
+    display: inline-flex;
+    padding: 12rem 3.2rem 11.9rem 3.3rem;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .password-eye,
+  input,
+  button,
+  footer,
+  section {
+    max-width: 40rem;
+  }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -68,8 +68,8 @@ nav {
 }
 
 .hero-image {
-  width: 120rem;
-  height: 59rem;
+  width: 1200px;
+  height: 590px;
 }
 
 article {
@@ -136,8 +136,8 @@ section:nth-of-type(even) {
 
 .content-image {
   grid-area: image;
-  width: 55rem;
-  height: 45rem;
+  width: 550px;
+  height: 450px;
 }
 
 footer {
@@ -180,4 +180,51 @@ footer {
   display: flex;
   column-gap: 1.2rem;
   height: 2rem;
+}
+
+@media (max-width: 1199px) {
+  .hero-header {
+    padding-top: 4rem;
+  }
+  
+  .hero-image {
+    width: 698px;
+    height: 343px;
+  }
+  
+  article {
+    padding-top: 3rem;
+  }
+  
+  section {
+    column-gap: 5.1rem;
+    height: 41.5rem;
+  }
+  
+  section:nth-of-type(odd) {
+    grid-template: none;
+    grid-template-areas:
+      ". image"
+      "title image"
+      "description image"
+      ". image";
+  }
+  
+  section:nth-of-type(even) {
+    grid-template: none;
+    grid-template-areas:
+      "image ."
+      "image title"
+      "image description"
+      "image ."
+  }
+  
+  .content-image {
+    width: 385px;
+    height: 315px;
+  }
+}
+
+@media (max-width: 767px) {
+  
 }

--- a/src/style.css
+++ b/src/style.css
@@ -20,6 +20,11 @@ nav {
   right: 0;
 }
 
+nav>img {
+  width: 133px;
+  height: 24px;
+}
+
 .hero-header {
   display: flex;
   flex-direction: column;
@@ -85,24 +90,6 @@ section {
   width: 100%;
   height: 55rem;
   padding: 50px 0;
-}
-
-section:nth-of-type(odd) {
-  grid-template:
-    ". image"
-    "title image"
-    "description image"
-    ". image"
-    /291px 55rem;
-}
-
-section:nth-of-type(even) {
-  grid-template:
-    "image ."
-    "image title"
-    "image description"
-    "image ."
-    /550px 29.1rem;
 }
 
 .title {
@@ -182,7 +169,116 @@ footer {
   height: 2rem;
 }
 
-@media (max-width: 1199px) {
+
+
+
+
+
+/* 모바일 크기 */
+@media (max-width: 767px) {
+  nav {
+    height: 6.3rem;
+    padding: 0 3.2rem;
+  }
+
+  nav>img {
+    width: 88.667px;
+    height: 16px;
+  }
+  
+  .hero-header {
+    row-gap: 2.4rem;
+    padding-top: 2.8rem;
+    padding: 2.8rem 3.2rem 0;
+    margin-top: 6.3rem;
+  }
+  
+  .cta {
+    height: 3.7rem;
+    font-size: 1.4rem;
+  }
+  
+  .cta-short {
+    width: 8rem;
+  }
+  
+  .cta-long {
+    width: 20rem;
+  }
+  
+  .slogan {
+    font-size: 3.2rem;
+    line-height: 4.2rem;
+  }
+  
+  .hero-image {
+    width: 100%;
+    height: 100%;
+  }
+  
+  article {
+    padding: 0 3.2rem 4rem;
+  }
+  
+  section {
+    row-gap: 2.4rem;
+    height: auto;
+    padding: 4rem 0;
+
+    display: grid;
+    grid-template:
+      "title"
+      "image"
+      "description";
+  }
+  
+  .title {
+    font-size: 2.4rem;
+  }
+  
+  .description {
+    font-size: 1.5rem;
+    font-weight: 400;
+  }
+
+  br {
+    display: none;
+  }
+  
+  .content-image {
+    width: 100%;
+    height: 100%;
+  }
+  
+  .footer-box {
+    display: grid;
+    grid-template-areas:
+      "links sns"
+      "copyright .";
+    row-gap: 6rem;
+    padding: 0 3.2rem;
+  }
+  
+  .copyright {
+    grid-area: copyright;
+    font-weight: 400;
+  }
+  
+  .footer-links {
+    grid-area: links;
+  }
+  
+  .footer-link {
+    font-size: 1.6rem;
+    font-weight: 400;
+  }
+}
+
+
+
+
+/* 태블릿 크기 */
+@media (min-width: 768px) {
   .hero-header {
     padding-top: 4rem;
   }
@@ -225,6 +321,27 @@ footer {
   }
 }
 
-@media (max-width: 767px) {
-  
+
+
+
+
+/* 컴퓨터 크기 */
+@media (min-width: 1200px) {
+  section:nth-of-type(odd) {
+    grid-template:
+      ". image"
+      "title image"
+      "description image"
+      ". image"
+      /291px 55rem;
+  }
+
+  section:nth-of-type(even) {
+    grid-template:
+      "image ."
+      "image title"
+      "image description"
+      "image ."
+      /550px 29.1rem;
+  }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -20,7 +20,7 @@ nav {
   right: 0;
 }
 
-nav>img {
+nav img {
   width: 133px;
   height: 24px;
 }
@@ -181,9 +181,9 @@ footer {
     padding: 0 3.2rem;
   }
 
-  nav>img {
-    width: 88.667px;
-    height: 16px;
+  nav img {
+    width: 8.8667rem;
+    height: 1.6rem;
   }
   
   .hero-header {
@@ -320,6 +320,22 @@ footer {
     height: 315px;
   }
 }
+
+
+
+
+/* nav바 반응형 여백 */
+@media (max-width: 1199px) {
+  nav {
+    padding: 0 calc((100% - 78.3rem) / 2);
+  }
+}
+@media (max-width: 863px) {
+  nav {
+    padding: 0 3.2rem;
+  }
+}
+
 
 
 


### PR DESCRIPTION
## 요구사항

### 기본


 - [x] [기본] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용했나요?
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다
- [x] [랜딩 페이지] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정했나요?
- [x] [랜딩 페이지] 미리보기에서 제목은 “Linkbrary”, 설명은 “세상의 모든 정보를 쉽게 저장하고 관리해 보세요”로 설정했나요?
- [x] [랜딩 페이지] 주소와 이미지는 자유롭게 설정했나요?
- [x] [랜딩 페이지] Tablet 사이즈에서 화면의 너비가 1199px 이하로 작아질 때 “Linkbrary” 로고와 “로그인” 버튼 사이의 간격은 변하지 않게 고정값으로 유지하되 좌우 여백이 줄어드나요?
- [x] [랜딩 페이지] Tablet 사이즈에서 최소 좌우 여백은 “Linkbrary” 로고의 왼쪽에 여백 32px, “로그인” 버튼 오른쪽 여백 32px을 유지하고“Linkbrary” 로고와 “로그인" 버튼의 간격이 가까워지나요?
- [x] [랜딩 페이지] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용했나요?
- [x] [랜딩 페이지] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차나요?
(이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
- [x] [랜딩 페이지] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 커지나요?
- [x] [로그인, 회원가입 페이지] Tablet 사이즈에서 디자인은 PC사이즈와 동일한가요?
- [x] [로그인, 회원가입 페이지] Mobile 사이즈에서 좌우 여백 32px 제외하고 내부 요소들이 너비를 모두 차지하나요?
- [x] [로그인, 회원가입 페이지] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않나요?


### 심화

- [ ] [심화] 팀원의 위클리 미션 PR에 코드 리뷰를 남겼나요?
- [x] [심화] 랜딩 페이지 Mobile 사이즈에서 제품 소개 영역의 순서를 제목, 설명, 이미지 => 제목, 이미지, 설명 순서로 변경했나요?

## 주요 변경사항

- 루트(/), 로그인, 회원가입 페이지의 화면 너비에 대한 반응 추가
- 공유시 미리보기 정보 추가

## 스크린샷

![로그인](https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/151595973/d0841b70-e501-4526-80d0-fb945497f69b)
![회원가입](https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/151595973/ad3c0ee7-162e-4d9b-95ee-5789d382d802)
![랜딩 페이지](https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/151595973/75f0212f-5ca2-4caf-8f09-8885e86477a0)


## 멘토에게

- calc()함수를 통해 여백을 줄이긴 했지만 여백이 32px가 되었을 때의 화면의 넓이를 미리 계산해야 자연스럽게 여백을 32px로 고정시킬 수 있었습니다. 다른 쉬운 방법이 뭐가 있을까요?

