### PR TITLE
[이유연] Week4

### DIFF
--- a/folder.html
+++ b/folder.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    folder.html
+  </body>
+</html>

--- a/scripts/singin.js
+++ b/scripts/singin.js
@@ -1,50 +1,18 @@
-const emailInput = document.querySelector("#email");
-const pwdInput = document.querySelector("#password");
-const eyeIcons = document.querySelectorAll(".eye-icon");
-const errorMsgs = document.querySelectorAll(".error-message");
-const loginForm = document.querySelector("#login-form");
-
-const toggleIcon = (element, password) => {
-  password.type = password.type === "password" ? "text" : "password";
-  element.src =
-    password.type === "password" ? "images/eye-off.svg" : "images/eye-on.svg";
-};
+import {
+  emailInput,
+  pwdInput,
+  eyeIcons,
+  errorMsgs,
+  loginForm,
+} from "./tags.js";
+import toggleIcon from "./toggleIcon.js";
+import { isValidEmail, isValidPwd } from "./validation.js";
 
 eyeIcons[0].addEventListener("click", () => toggleIcon(eyeIcons[0], pwdInput));
-
-/* 이메일 유효성 검사 */
-const isValidEmail = (element) => {
-  const isEmpty = element.value.length === 0;
-  const isInvalidPattern = !/^[a-z0-9]+@[a-z]+\.[a-z]{2,3}$/.test(
-    element.value
-  );
-
-  element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
-
-  errorMsgs[0].textContent = isEmpty
-    ? "이메일을 입력해주세요."
-    : isInvalidPattern
-    ? "올바른 이메일 주소가 아닙니다."
-    : "";
-};
-
-/* 비밀번호 유효성 검사 */
-const isValidPwd = (element) => {
-  const isEmpty = element.value.length === 0;
-  const isInvalidPattern =
-    !/(?=.*[a-zA-Z])(?=.*\d).*/.test(element.value) || element.value.length < 8;
-
-  element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
-
-  errorMsgs[1].textContent = isEmpty
-    ? "비밀번호를 입력해주세요."
-    : isInvalidPattern
-    ? "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
-    : "";
-};
-
-emailInput.addEventListener("focusout", () => isValidEmail(emailInput));
-pwdInput.addEventListener("focusout", () => isValidPwd(pwdInput));
+emailInput.addEventListener("focusout", () =>
+  isValidEmail(emailInput, errorMsgs)
+);
+pwdInput.addEventListener("focusout", () => isValidPwd(pwdInput, errorMsgs));
 
 /* "test@codeit.com" 이메일과 "codeit101" 비밀번호로 로그인하면 이동, 틀리면 오류메세지 */
 loginForm.addEventListener("submit", (e) => {

--- a/scripts/singin.js
+++ b/scripts/singin.js
@@ -1,6 +1,6 @@
 import {
   emailInput,
-  pwdInput,
+  pwdInputs,
   eyeIcons,
   errorMsgs,
   loginForm,
@@ -8,11 +8,15 @@ import {
 import toggleIcon from "./toggleIcon.js";
 import { isValidEmail, isValidPwd } from "./validation.js";
 
-eyeIcons[0].addEventListener("click", () => toggleIcon(eyeIcons[0], pwdInput));
-emailInput.addEventListener("focusout", () =>
-  isValidEmail(emailInput, errorMsgs)
+eyeIcons[0].addEventListener("click", () =>
+  toggleIcon(eyeIcons[0], pwdInputs[0])
 );
-pwdInput.addEventListener("focusout", () => isValidPwd(pwdInput, errorMsgs));
+emailInput.addEventListener("focusout", () =>
+  isValidEmail(emailInput, errorMsgs[0])
+);
+pwdInputs[0].addEventListener("focusout", () =>
+  isValidPwd(pwdInputs[0], errorMsgs[1])
+);
 
 /* "test@codeit.com" 이메일과 "codeit101" 비밀번호로 로그인하면 이동, 틀리면 오류메세지 */
 loginForm.addEventListener("submit", (e) => {
@@ -21,11 +25,11 @@ loginForm.addEventListener("submit", (e) => {
   const rightEmail = "test@codeit.com";
   const rightPwd = "codeit101";
 
-  if (emailInput.value === rightEmail && pwdInput.value === rightPwd) {
+  if (emailInput.value === rightEmail && pwdInputs[0].value === rightPwd) {
     window.location.href = "folder.html";
   } else {
     emailInput.classList.add("invalid-border");
-    pwdInput.classList.add("invalid-border");
+    pwdInputs[0].classList.add("invalid-border");
     errorMsgs[0].textContent = "이메일을 확인해주세요.";
     errorMsgs[1].textContent = "비밀번호를 확인해주세요.";
   }

--- a/scripts/singin.js
+++ b/scripts/singin.js
@@ -12,18 +12,35 @@ const toggleIcon = (element, password) => {
 eyeIcons[0].addEventListener("click", () => toggleIcon(eyeIcons[0], pwdInput));
 
 /* 이메일 유효성 검사 */
-
 const isValidEmail = (element) => {
   const isEmpty = element.value.length === 0;
-  const validPattern = !/^[a-z0-9]+@[a-z]+\.[a-z]{2,3}$/.test(element.value);
+  const isInvalidPattern = !/^[a-z0-9]+@[a-z]+\.[a-z]{2,3}$/.test(
+    element.value
+  );
 
-  element.classList.toggle("invalid-border", isEmpty || validPattern);
+  element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
 
   errorMsgs[0].textContent = isEmpty
     ? "이메일을 입력해주세요."
-    : validPattern
+    : isInvalidPattern
     ? "올바른 이메일 주소가 아닙니다."
     : "";
 };
 
+/* 비밀번호 유효성 검사 */
+const isValidPwd = (element) => {
+  const isEmpty = element.value.length === 0;
+  const isInvalidPattern =
+    !/(?=.*[a-zA-Z])(?=.*\d).*/.test(element.value) || element.value.length < 8;
+
+  element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
+
+  errorMsgs[1].textContent = isEmpty
+    ? "비밀번호를 입력해주세요."
+    : isInvalidPattern
+    ? "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
+    : "";
+};
+
 emailInput.addEventListener("focusout", () => isValidEmail(emailInput));
+pwdInput.addEventListener("focusout", () => isValidPwd(pwdInput));

--- a/scripts/singin.js
+++ b/scripts/singin.js
@@ -1,0 +1,10 @@
+const pwdInput = document.querySelector("#password");
+const eyeIcons = document.querySelectorAll(".eye-icon");
+
+const toggleIcon = (element, password) => {
+  password.type = password.type === "password" ? "text" : "password";
+  element.src =
+    password.type === "password" ? "images/eye-off.svg" : "images/eye-on.svg";
+};
+
+eyeIcons[0].addEventListener("click", () => toggleIcon(eyeIcons[0], pwdInput));

--- a/scripts/singin.js
+++ b/scripts/singin.js
@@ -1,5 +1,7 @@
+const emailInput = document.querySelector("#email");
 const pwdInput = document.querySelector("#password");
 const eyeIcons = document.querySelectorAll(".eye-icon");
+const errorMsgs = document.querySelectorAll(".error-message");
 
 const toggleIcon = (element, password) => {
   password.type = password.type === "password" ? "text" : "password";
@@ -8,3 +10,20 @@ const toggleIcon = (element, password) => {
 };
 
 eyeIcons[0].addEventListener("click", () => toggleIcon(eyeIcons[0], pwdInput));
+
+/* 이메일 유효성 검사 */
+
+const isValidEmail = (element) => {
+  const isEmpty = element.value.length === 0;
+  const validPattern = !/^[a-z0-9]+@[a-z]+\.[a-z]{2,3}$/.test(element.value);
+
+  element.classList.toggle("invalid-border", isEmpty || validPattern);
+
+  errorMsgs[0].textContent = isEmpty
+    ? "이메일을 입력해주세요."
+    : validPattern
+    ? "올바른 이메일 주소가 아닙니다."
+    : "";
+};
+
+emailInput.addEventListener("focusout", () => isValidEmail(emailInput));

--- a/scripts/singin.js
+++ b/scripts/singin.js
@@ -2,6 +2,7 @@ const emailInput = document.querySelector("#email");
 const pwdInput = document.querySelector("#password");
 const eyeIcons = document.querySelectorAll(".eye-icon");
 const errorMsgs = document.querySelectorAll(".error-message");
+const loginForm = document.querySelector("#login-form");
 
 const toggleIcon = (element, password) => {
   password.type = password.type === "password" ? "text" : "password";
@@ -44,3 +45,20 @@ const isValidPwd = (element) => {
 
 emailInput.addEventListener("focusout", () => isValidEmail(emailInput));
 pwdInput.addEventListener("focusout", () => isValidPwd(pwdInput));
+
+/* "test@codeit.com" 이메일과 "codeit101" 비밀번호로 로그인하면 이동, 틀리면 오류메세지 */
+loginForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+
+  const rightEmail = "test@codeit.com";
+  const rightPwd = "codeit101";
+
+  if (emailInput.value === rightEmail && pwdInput.value === rightPwd) {
+    window.location.href = "folder.html";
+  } else {
+    emailInput.classList.add("invalid-border");
+    pwdInput.classList.add("invalid-border");
+    errorMsgs[0].textContent = "이메일을 확인해주세요.";
+    errorMsgs[1].textContent = "비밀번호를 확인해주세요.";
+  }
+});

--- a/scripts/singin.js
+++ b/scripts/singin.js
@@ -8,9 +8,12 @@ import {
 import toggleIcon from "./toggleIcon.js";
 import { isValidEmail, isValidPwd } from "./validation.js";
 
+/* 눈모양 아이콘 누르면 비밀번호 보이기 */
 eyeIcons[0].addEventListener("click", () =>
   toggleIcon(eyeIcons[0], pwdInputs[0])
 );
+
+/* 이메일 및 비밀번호 유효성 검사 */
 emailInput.addEventListener("focusout", () =>
   isValidEmail(emailInput, errorMsgs[0])
 );

--- a/scripts/singup.js
+++ b/scripts/singup.js
@@ -8,29 +8,47 @@ import {
 import toggleIcon from "./toggleIcon.js";
 import { isValidEmail, isValidPwd } from "./validation.js";
 
+/* 눈모양 아이콘 누르면 비밀번호 보이기 */
 eyeIcons.forEach((el, idx) =>
   el.addEventListener("click", () => toggleIcon(el, pwdInputs[idx]))
 );
-emailInput.addEventListener("focusout", () =>
-  isValidEmail(emailInput, errorMsgs[0])
-);
-pwdInputs.forEach((el, idx) =>
-  el.addEventListener("focusout", () => isValidPwd(el, errorMsgs[idx + 1]))
-);
 
-signupForm.addEventListener("submit", (e) => {
-  e.preventDefault();
-
+/* 이메일 및 비밀번호 유효성 검사 */
+emailInput.addEventListener("focusout", () => {
   const isExistEmail = emailInput.value === "test@codeit.com";
-  const isEmptyInput =
-    emailInput.value.length === 0 || pwdInputs[0].value.length === 0;
-  const isEmptyError = [...errorMsgs].some((el) => el.textContent.length > 0);
-
   /* "test@codeit.com"로 회원가입 시도 시 오류 메세지 */
   if (isExistEmail) {
     emailInput.classList.toggle("invalid-border", isExistEmail);
     errorMsgs[0].textContent = "이미 사용중인 이메일 입니다.";
-  } else if (!isEmptyInput && !isEmptyError) {
+  } else {
+    isValidEmail(emailInput, errorMsgs[0]);
+  }
+});
+
+pwdInputs[0].addEventListener("focusout", () =>
+  isValidPwd(pwdInputs[0], errorMsgs[1])
+);
+
+/* 비밀번호 확인 입력값이 비밀번호 입력값과 같은 지 검사 */
+pwdInputs[1].addEventListener("focusout", () => {
+  const checkPassword = pwdInputs[0].value !== pwdInputs[1].value;
+  if (checkPassword) {
+    pwdInputs[1].classList.toggle("invalid-border", checkPassword);
+    errorMsgs[2].textContent = checkPassword ? "비밀번호가 다릅니다." : "";
+  } else {
+    isValidPwd(pwdInputs[1], errorMsgs[2]);
+  }
+});
+
+/* 유효한 회원가입 시도 시 페이지 이동 */
+signupForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+
+  const isEmptyInput =
+    emailInput.value.length === 0 || pwdInputs[0].value.length === 0;
+  const isEmptyError = [...errorMsgs].some((el) => el.textContent.length > 0);
+
+  if (!isEmptyInput && !isEmptyError) {
     /* input이 비어있지 않으면서 오류 메시지가 없으면 회원가입 성공 */
     window.location.href = "folder.html";
   }

--- a/scripts/singup.js
+++ b/scripts/singup.js
@@ -17,3 +17,15 @@ emailInput.addEventListener("focusout", () =>
 pwdInputs.forEach((el, idx) =>
   el.addEventListener("focusout", () => isValidPwd(el, errorMsgs[idx + 1]))
 );
+
+signupForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+  if (emailInput.value === "test@codeit.com") {
+    emailInput.classList.toggle(
+      "invalid-border",
+      emailInput.value === "test@codeit.com"
+    );
+    errorMsgs[0].textContent = "이미 사용중인 이메일 입니다.";
+  } else {
+  }
+});

--- a/scripts/singup.js
+++ b/scripts/singup.js
@@ -20,12 +20,18 @@ pwdInputs.forEach((el, idx) =>
 
 signupForm.addEventListener("submit", (e) => {
   e.preventDefault();
-  if (emailInput.value === "test@codeit.com") {
-    emailInput.classList.toggle(
-      "invalid-border",
-      emailInput.value === "test@codeit.com"
-    );
+
+  const isExistEmail = emailInput.value === "test@codeit.com";
+  const isEmptyInput =
+    emailInput.value.length === 0 || pwdInputs[0].value.length === 0;
+  const isEmptyError = [...errorMsgs].some((el) => el.textContent.length > 0);
+
+  /* "test@codeit.com"로 회원가입 시도 시 오류 메세지 */
+  if (isExistEmail) {
+    emailInput.classList.toggle("invalid-border", isExistEmail);
     errorMsgs[0].textContent = "이미 사용중인 이메일 입니다.";
-  } else {
+  } else if (!isEmptyInput && !isEmptyError) {
+    /* input이 비어있지 않으면서 오류 메시지가 없으면 회원가입 성공 */
+    window.location.href = "folder.html";
   }
 });

--- a/scripts/singup.js
+++ b/scripts/singup.js
@@ -1,0 +1,19 @@
+import {
+  emailInput,
+  pwdInputs,
+  eyeIcons,
+  errorMsgs,
+  signupForm,
+} from "./tags.js";
+import toggleIcon from "./toggleIcon.js";
+import { isValidEmail, isValidPwd } from "./validation.js";
+
+eyeIcons.forEach((el, idx) =>
+  el.addEventListener("click", () => toggleIcon(el, pwdInputs[idx]))
+);
+emailInput.addEventListener("focusout", () =>
+  isValidEmail(emailInput, errorMsgs[0])
+);
+pwdInputs.forEach((el, idx) =>
+  el.addEventListener("focusout", () => isValidPwd(el, errorMsgs[idx + 1]))
+);

--- a/scripts/singup.js
+++ b/scripts/singup.js
@@ -51,5 +51,12 @@ signupForm.addEventListener("submit", (e) => {
   if (!isEmptyInput && !isEmptyError) {
     /* input이 비어있지 않으면서 오류 메시지가 없으면 회원가입 성공 */
     window.location.href = "folder.html";
+  } else {
+    emailInput.classList.add("invalid-border");
+    pwdInputs[0].classList.add("invalid-border");
+    pwdInputs[1].classList.add("invalid-border");
+    errorMsgs[0].textContent = "이메일을 확인해주세요.";
+    errorMsgs[1].textContent = "비밀번호를 확인해주세요.";
+    errorMsgs[2].textContent = "비밀번호를 확인해주세요.";
   }
 });

--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -1,7 +1,8 @@
 const emailInput = document.querySelector("#email");
-const pwdInput = document.querySelector("#password");
+const pwdInputs = document.querySelectorAll(".password");
 const eyeIcons = document.querySelectorAll(".eye-icon");
 const errorMsgs = document.querySelectorAll(".error-message");
 const loginForm = document.querySelector("#login-form");
+const signupForm = document.querySelector("#signup-form");
 
-export { emailInput, pwdInput, eyeIcons, errorMsgs, loginForm };
+export { emailInput, pwdInputs, eyeIcons, errorMsgs, loginForm, signupForm };

--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -1,0 +1,7 @@
+const emailInput = document.querySelector("#email");
+const pwdInput = document.querySelector("#password");
+const eyeIcons = document.querySelectorAll(".eye-icon");
+const errorMsgs = document.querySelectorAll(".error-message");
+const loginForm = document.querySelector("#login-form");
+
+export { emailInput, pwdInput, eyeIcons, errorMsgs, loginForm };

--- a/scripts/toggleIcon.js
+++ b/scripts/toggleIcon.js
@@ -1,0 +1,7 @@
+const toggleIcon = (element, password) => {
+  password.type = password.type === "password" ? "text" : "password";
+  element.src =
+    password.type === "password" ? "images/eye-off.svg" : "images/eye-on.svg";
+};
+
+export default toggleIcon;

--- a/scripts/validation.js
+++ b/scripts/validation.js
@@ -1,0 +1,32 @@
+/* 이메일 유효성 검사 */
+const isValidEmail = (element, message) => {
+  const isEmpty = element.value.length === 0;
+  const isInvalidPattern = !/^[a-z0-9]+@[a-z]+\.[a-z]{2,3}$/.test(
+    element.value
+  );
+
+  element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
+
+  message[0].textContent = isEmpty
+    ? "이메일을 입력해주세요."
+    : isInvalidPattern
+    ? "올바른 이메일 주소가 아닙니다."
+    : "";
+};
+
+/* 비밀번호 유효성 검사 */
+const isValidPwd = (element, message) => {
+  const isEmpty = element.value.length === 0;
+  const isInvalidPattern =
+    !/(?=.*[a-zA-Z])(?=.*\d).*/.test(element.value) || element.value.length < 8;
+
+  element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
+
+  message[1].textContent = isEmpty
+    ? "비밀번호를 입력해주세요."
+    : isInvalidPattern
+    ? "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
+    : "";
+};
+
+export { isValidEmail, isValidPwd };

--- a/scripts/validation.js
+++ b/scripts/validation.js
@@ -7,7 +7,7 @@ const isValidEmail = (element, message) => {
 
   element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
 
-  message[0].textContent = isEmpty
+  message.textContent = isEmpty
     ? "이메일을 입력해주세요."
     : isInvalidPattern
     ? "올바른 이메일 주소가 아닙니다."
@@ -22,7 +22,7 @@ const isValidPwd = (element, message) => {
 
   element.classList.toggle("invalid-border", isEmpty || isInvalidPattern);
 
-  message[1].textContent = isEmpty
+  message.textContent = isEmpty
     ? "비밀번호를 입력해주세요."
     : isInvalidPattern
     ? "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."

--- a/signin.html
+++ b/signin.html
@@ -34,6 +34,7 @@
               alt="비밀번호 확인하기"
             />
           </div>
+          <p class="error-message"></p>
           <button type="submit">로그인</button>
         </form>
       </div>

--- a/signin.html
+++ b/signin.html
@@ -21,7 +21,7 @@
           </a>
           <p>회원이 아니신가요? <a href="signup.html">회원 가입하기</a></p>
         </header>
-        <form aria-labelledby="login-form-title">
+        <form id="login-form">
           <label for="email">이메일</label>
           <input type="email" id="email" placeholder="codeit@codeit.com" />
           <label for="password">비밀번호</label>
@@ -48,5 +48,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="scripts/singin.js" />
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -27,7 +27,11 @@
           <p class="error-message"></p>
           <label for="password">비밀번호</label>
           <div>
-            <input type="password" id="password" placeholder="비밀번호 입력" />
+            <input
+              type="password"
+              class="password"
+              placeholder="비밀번호 입력"
+            />
             <img
               class="eye-icon"
               src="images/eye-off.svg"

--- a/signin.html
+++ b/signin.html
@@ -24,6 +24,7 @@
         <form id="login-form">
           <label for="email">이메일</label>
           <input type="email" id="email" placeholder="codeit@codeit.com" />
+          <p class="error-message"></p>
           <label for="password">비밀번호</label>
           <div>
             <input type="password" id="password" placeholder="비밀번호 입력" />

--- a/signin.html
+++ b/signin.html
@@ -54,6 +54,6 @@
         </div>
       </div>
     </main>
-    <script type="module" src="scripts/singin.js" />
+    <script type="module" src="scripts/singin.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -21,27 +21,38 @@
           </a>
           <p>이미 회원이신가요? <a href="signin.html">로그인 하기</a></p>
         </header>
-        <form aria-labelledby="signin-form-title">
+        <form id="signup-form">
           <label for="email">이메일</label>
           <input type="email" id="email" placeholder="codeit@codeit.com" />
+          <p class="error-message"></p>
           <label for="password">비밀번호</label>
           <div>
-            <input type="password" id="password" placeholder="비밀번호 입력" />
+            <input
+              type="password"
+              class="password"
+              placeholder="비밀번호 입력"
+            />
             <img
               class="eye-icon"
               src="images/eye-off.svg"
               alt="비밀번호 확인하기"
             />
           </div>
+          <p class="error-message"></p>
           <label for="password">비밀번호 확인</label>
           <div>
-            <input type="password" id="password" placeholder="비밀번호 입력" />
+            <input
+              type="password"
+              class="password"
+              placeholder="비밀번호 입력"
+            />
             <img
               class="eye-icon"
               src="images/eye-off.svg"
               alt="비밀번호 확인하기"
             />
           </div>
+          <p class="error-message"></p>
           <button type="submit">회원가입</button>
         </form>
       </div>
@@ -57,5 +68,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="scripts/singup.js"></script>
   </body>
 </html>

--- a/src/sign.css
+++ b/src/sign.css
@@ -89,6 +89,16 @@ input:focus {
   border: 1px solid var(--primary);
 }
 
+.invalid-border {
+  border: 1px solid var(--red);
+}
+
+.error-message {
+  font-size: 14px;
+  color: var(--red);
+  margin-top: 6px;
+}
+
 form > button {
   display: flex;
   padding: 16px 20px;


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] [기본]이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- singin.html과 singup.html에 오류 메시지 보여줄 p태그 추가
- 로그인 및 회원가입 유효성 검증 로직 추가

## 스크린샷

<img width="300" alt="image" src="https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/127701092/18913f55-00da-4a04-9804-c63d550221b5">
<img width="300" alt="image" src="https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/127701092/517079d3-4799-40e2-9efa-42433f0b9f3a">
<img width="300" alt="image" src="https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/127701092/d469ebc9-6552-4118-9b39-8048f6f78062">
<img width="300" alt="image" src="https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/127701092/6cccd7a9-3f5c-4e83-adcd-85ffa5f7cbc2">


## 링크

https://codeitlinkbrary.netlify.app/signin

## 멘토에게

- id랑 class를 이용하는 명확한 기준이 있나요.. 그냥 유일한건 id로 하고 아닌건 class로 하니까 너무 헷갈립니다.
- 유효한 이메일+비밀번호일 경우 회원가입 버튼을 누르면 페이지 이동이 되도록 하긴 했는데
 오류메시지가 비어있으면 && input이 비어있지 않으면 이라는 조건이라서 좀 어거지같아서 다른 방법 뭐가 있는지 원래 이런 로직은 어떤 식으로 하는게 맞는지 궁금합니다.
- 그냥 이렇게 구조를 짜는게 맞는건지 아닌지를 아예 모르겠습니다 ㅎㅎ..
- 잘못 수정해서 취소하고 싶은 커밋이 있어서 로컬에서 reset하고 그냥 force옵션으로 push해서 해결했는데 force는 진짜 최대한 쓰지말라고 하길래 여쭤봅니다. revert로 커밋기록을 여러 개 남기면서 하는게 force 쓰는 것 보단 낫나요..?
