### PR TITLE
[이치현] Week5

### DIFF
--- a/sign_module.js
+++ b/sign_module.js
@@ -1,23 +1,3 @@
-// export function validateEmail(emailInput, emailError) {
-//   const email = emailInput.value;
-//   if (email.length === 0) {
-//     emailError.textContent = '이메일을 입력해주세요.';
-//     emailError.style.display = 'block';
-//     emailInput.classList.add('input-error');
-//     return;
-//   }
-
-//   if (!email.includes('@')) {
-//     emailError.textContent = '올바른 이메일 주소가 아닙니다.';
-//     emailError.style.display = 'block';
-//     emailInput.classList.add('input-error');
-//     return;
-//   }
-
-//   emailError.style.display = 'none';
-//   emailInput.classList.remove('input-error');
-// }
-
 export function validateEmail(emailInput, emailError) {
   const email = emailInput.value;
   const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/

--- a/sign_module.js
+++ b/sign_module.js
@@ -1,6 +1,7 @@
+const EMAIL_REGEX = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/
+
 export function validateEmail(emailInput, emailError) {
   const email = emailInput.value;
-  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/
 
   if (email.length === 0) {
     emailError.textContent = '이메일을 입력해주세요.';
@@ -9,7 +10,7 @@ export function validateEmail(emailInput, emailError) {
     return;
   }
 
-  if (!emailRegex.test(email)) {
+  if (!EMAIL_REGEX.test(email)) {
     emailError.textContent = '올바른 이메일 주소가 아닙니다.';
     emailError.style.display = 'block';
     emailInput.classList.add('input-error');

--- a/signin.js
+++ b/signin.js
@@ -1,7 +1,25 @@
 import { validateEmail, validatePassword, togglePasswordVisibility } from './sign_module.js';
 
-const CORRECT_EMAIL = 'test@codeit.com';
-const CORRECT_PASSWORD = 'codeit101';
+const fetchSignIn = async (email, password) => {
+  let myHeaders = new Headers();
+  myHeaders.append("Content-Type", "application/json");
+
+  let raw = JSON.stringify({
+    email,
+    password,
+  });
+
+  let requestOptions = {
+    method: 'POST',
+    headers: myHeaders,
+    body: raw,
+    redirect: 'follow'
+  };
+
+  const res = await fetch("https://bootcamp-api.codeit.kr/api/sign-in", requestOptions)
+
+  return res;
+}
 
 document.addEventListener('DOMContentLoaded', function () {
   const emailInput = document.getElementById('email');
@@ -26,13 +44,17 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   const loginButton = document.querySelector('.cta');
-  loginButton.addEventListener('click', function (event) {
+  loginButton.addEventListener('click', async function (event) {
     event.preventDefault();
     validateEmail(emailInput, emailError);
     validatePassword(passwordInput, passwordError);
 
-    if (emailInput.value === CORRECT_EMAIL && passwordInput.value === CORRECT_PASSWORD) {
-      window.location.href = '/folder';
+    const response = await fetchSignIn(emailInput.value, passwordInput.value);
+
+    if (response.ok) {
+      window.location.href = "/folder";
+    } else {
+      alert("이메일 또는 비밀번호가 일치하지 않습니다.");
     }
   });
 });

--- a/signin.js
+++ b/signin.js
@@ -29,6 +29,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const eyeButtons = document.getElementsByClassName('eye-button');
 
+  const accessTokenFromLocalStorage = localStorage.getItem("accessToken");
+
+  if (accessTokenFromLocalStorage) {
+    window.location.href = "/folder";
+  }
+
   Array.from(eyeButtons).forEach(function (button) {
     button.addEventListener('click', function () {
       togglePasswordVisibility(this);
@@ -52,6 +58,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const response = await fetchSignIn(emailInput.value, passwordInput.value);
 
     if (response.ok) {
+      const res = JSON.parse(await response.text());
+      localStorage.setItem("accessToken", res.data.accessToken);
       window.location.href = "/folder";
     } else {
       alert("이메일 또는 비밀번호가 일치하지 않습니다.");

--- a/signin.js
+++ b/signin.js
@@ -4,12 +4,12 @@ const fetchSignIn = async (email, password) => {
   let myHeaders = new Headers();
   myHeaders.append("Content-Type", "application/json");
 
-  let raw = JSON.stringify({
+  const raw = JSON.stringify({
     email,
     password,
   });
 
-  let requestOptions = {
+  const requestOptions = {
     method: 'POST',
     headers: myHeaders,
     body: raw,

--- a/signup.js
+++ b/signup.js
@@ -4,11 +4,11 @@ const fetchCheckEmail = async (email) => {
   let myHeaders = new Headers();
   myHeaders.append("Content-Type", "application/json");
 
-  let raw = JSON.stringify({
+  const raw = JSON.stringify({
     email,
   });
 
-  let requestOptions = {
+  const requestOptions = {
     method: 'POST',
     headers: myHeaders,
     body: raw,

--- a/signup.js
+++ b/signup.js
@@ -1,5 +1,25 @@
 import { validateEmail, validatePassword, togglePasswordVisibility } from './sign_module.js';
 
+const fetchCheckEmail = async (email) => {
+  let myHeaders = new Headers();
+  myHeaders.append("Content-Type", "application/json");
+
+  let raw = JSON.stringify({
+    email,
+  });
+
+  let requestOptions = {
+    method: 'POST',
+    headers: myHeaders,
+    body: raw,
+    redirect: 'follow'
+  };
+
+  const res = await fetch("https://bootcamp-api.codeit.kr/api/check-email", requestOptions)
+
+  return res;
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   const emailInput = document.getElementById('email');
   const passwordInput = document.getElementById('password');
@@ -36,9 +56,18 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   const signupButton = document.querySelector('.cta');
-  signupButton.addEventListener('click', function (event) {
+  signupButton.addEventListener('click', async function (event) {
     event.preventDefault();
     validateEmail(emailInput, emailError);
     validatePassword(passwordInput, passwordError);
+
+    const response = await fetchCheckEmail(emailInput.value)
+
+    if (response.ok) {
+      window.location.href = "/folder";
+    } else {
+      alert("이미 존재하는 이메일 입니다.");
+    }
+
   });
 });


### PR DESCRIPTION
## 요구사항

### 기본

- [x] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [x] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [x] 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장했나요?
- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- api POST 요청 (로그인 시 페이지 전환, 회원가입 시 이메일 중복 확인)
- access Token 로컬 저장 (로컬 저장 시, 로그인 페이지 이동하면 페이지 전환)

## 스크린샷

<img width="528" alt="스크린샷 2023-12-26 오전 5 41 22" src="https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/150772344/4d56966c-dbdb-4a21-8ed9-0bb1e3f45b5c">
<img width="467" alt="스크린샷 2023-12-26 오전 5 42 59" src="https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/150772344/f6947773-5639-4e0f-a1a5-4a3b62e80b72">


## 멘토에게

- 이번 주도 잘 부탁드립니다. 감사합니다!🔥🔥🔥
- Netlify 링크 (https://657df4f34f9e7f6335fa9778--eclectic-toffee-5d18bb.netlify.app/)
