### PR TITLE
[윤해용] Week14

### DIFF
--- a/components/AuthButton/AuthButton.module.css
+++ b/components/AuthButton/AuthButton.module.css
@@ -1,0 +1,14 @@
+.button {
+  display: flex;
+  width: 400px;
+  padding: 16px 20px;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 8px;
+  background: linear-gradient(91deg, #6d6afe 0.12%, #6ae3fe 101.84%);
+
+  color: var(--Grey-Light, #f5f5f5);
+  font-size: 18px;
+  font-weight: 600;
+}

--- a/components/AuthButton/index.tsx
+++ b/components/AuthButton/index.tsx
@@ -1,0 +1,12 @@
+import { AuthButtonProps } from "@/lib/types";
+import styles from "./AuthButton.module.css";
+
+const AuthButton = ({ children = "로그인" }: AuthButtonProps) => {
+  return (
+    <button className={styles.button} type="submit">
+      {children}
+    </button>
+  );
+};
+
+export default AuthButton;

--- a/components/AuthButton/index.tsx
+++ b/components/AuthButton/index.tsx
@@ -1,7 +1,6 @@
-import { AuthButtonProps } from "@/lib/types";
 import styles from "./AuthButton.module.css";
 
-const AuthButton = ({ children = "로그인" }: AuthButtonProps) => {
+const AuthButton = ({ children = "로그인" }: { children: string }) => {
   return (
     <button className={styles.button} type="submit">
       {children}

--- a/components/AuthInput/AuthInput.module.css
+++ b/components/AuthInput/AuthInput.module.css
@@ -1,23 +1,25 @@
-.input-box {
+.passwordInput-container {
   position: relative;
-  width: 35rem;
+}
+
+.label {
+  font-size: 1.4rem;
 }
 
 .input-eye {
   position: absolute;
-  top: 50%;
-  right: 1rem;
-  transform: translate(-50%, -50%);
+  top: 5rem;
+  right: 2rem;
 }
 
 .input {
   display: flex;
-  width: 35rem;
+  width: 40rem;
+  margin-top: 1.2rem;
   padding: 1.8rem 1.5rem;
   justify-content: center;
   align-items: center;
   font-size: 1.6rem;
-  line-height: 24px;
   border-radius: 0.8rem;
   border: 1px solid var(--Linkbrary-gray20, #ccd5e3);
   background: var(--Linkbrary-white, #fff);

--- a/components/AuthInput/index.tsx
+++ b/components/AuthInput/index.tsx
@@ -129,6 +129,7 @@ const AuthInput = ({ type = "email", register, watch, errors, isSubmit }: AuthIn
                   id="password"
                   name="password"
                   type={isEyeIcon ? "text" : "password"}
+                  autoComplete="off"
                 />
                 {isSubmit ? (
                   <p className={styles["error-message"]}>{ERROR_MESSAGE.password.check}</p>
@@ -149,6 +150,7 @@ const AuthInput = ({ type = "email", register, watch, errors, isSubmit }: AuthIn
                   id="password"
                   name="password"
                   type={isEyeIcon ? "text" : "password"}
+                  autoComplete="off"
                 />
                 {(errors?.password?.type === "minLength" || errors?.password?.type === "pattern") && (
                   <p className={styles["error-message"]}>{ERROR_MESSAGE.password.vaild}</p>
@@ -165,6 +167,7 @@ const AuthInput = ({ type = "email", register, watch, errors, isSubmit }: AuthIn
                   id="passwordConfirm"
                   name="passwordConfirm"
                   type={isEyeIcon ? "text" : "password"}
+                  autoComplete="off"
                 />
                 {errors?.passwordConfirm?.type === "validate" && (
                   <p className={styles["error-message"]}>{ERROR_MESSAGE["passwordConfirm"].vaild}</p>

--- a/components/AuthInput/index.tsx
+++ b/components/AuthInput/index.tsx
@@ -47,7 +47,7 @@ const AuthInput = ({ type = "email", register, watch, errors, isSubmit }: AuthIn
 
   return (
     <>
-      {(type === "email" || type === "emailSignup") && (
+      {type === "email" && (
         <div className={styles["input-box"]}>
           <label className={styles.label} htmlFor="email">
             이메일
@@ -57,37 +57,52 @@ const AuthInput = ({ type = "email", register, watch, errors, isSubmit }: AuthIn
             {...register("email", {
               required: true,
               pattern: EMAIL_REGEX,
-              validate: async (value) => await checkEmail(value),
             })}
             id="email"
             name="email"
             type={type}
             placeholder={ERROR_MESSAGE.email.input}
           />
-          {type === "emailSignup" ? (
+          {isSubmit ? (
+            <p className={styles["error-message"]}>{ERROR_MESSAGE.email.check}</p>
+          ) : (
             <>
+              {errors?.email?.type === "required" && (
+                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.input}</p>
+              )}
               {errors?.email?.type === "pattern" && (
                 <p className={styles["error-message"]}>{ERROR_MESSAGE.email.correct}</p>
               )}
-              {errors?.email?.type === "validate" && (
-                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.duplication}</p>
-              )}
             </>
-          ) : (
-            <>
-              {isSubmit ? (
-                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.check}</p>
-              ) : (
-                <>
-                  {errors?.email?.type === "required" && (
-                    <p className={styles["error-message"]}>{ERROR_MESSAGE.email.input}</p>
-                  )}
-                  {errors?.email?.type === "pattern" && (
-                    <p className={styles["error-message"]}>{ERROR_MESSAGE.email.correct}</p>
-                  )}
-                </>
-              )}
-            </>
+          )}
+        </div>
+      )}
+
+      {type === "emailSignup" && (
+        <div className={styles["input-box"]}>
+          <label className={styles.label} htmlFor="emailSignup">
+            이메일
+          </label>
+          <input
+            className={styles.input}
+            {...register("emailSignup", {
+              required: true,
+              pattern: EMAIL_REGEX,
+              validate: async (value) => await checkEmail(value),
+            })}
+            id="emailSignup"
+            name="emailSignup"
+            type={type}
+            placeholder={ERROR_MESSAGE.email.input}
+          />
+          {errors?.emailSignup?.type === "required" && (
+            <p className={styles["error-message"]}>{ERROR_MESSAGE.email.input}</p>
+          )}
+          {errors?.emailSignup?.type === "pattern" && (
+            <p className={styles["error-message"]}>{ERROR_MESSAGE.email.correct}</p>
+          )}
+          {errors?.emailSignup?.type === "validate" && (
+            <p className={styles["error-message"]}>{ERROR_MESSAGE.email.duplication}</p>
           )}
         </div>
       )}
@@ -95,9 +110,15 @@ const AuthInput = ({ type = "email", register, watch, errors, isSubmit }: AuthIn
       {(type === "password" || type === "passwordSignup" || type === "passwordConfirm") && (
         <div className={styles["passwordInput-container"]}>
           <div className={styles["input-box"]}>
-            <label className={styles.label} htmlFor="password">
-              비밀번호
-            </label>
+            {type === "passwordConfirm" ? (
+              <label className={styles.label} htmlFor="passwordConfirm">
+                비밀번호 확인
+              </label>
+            ) : (
+              <label className={styles.label} htmlFor="password">
+                비밀번호
+              </label>
+            )}
 
             {type === "password" && (
               <>

--- a/components/AuthInput/index.tsx
+++ b/components/AuthInput/index.tsx
@@ -1,49 +1,101 @@
+import { UseFormRegister, FieldErrors } from "react-hook-form";
+import { EMAIL_REGEX } from "@/lib/utils";
 import { useState } from "react";
+import { FormInput } from "@/lib/types";
 import Image from "next/image";
 import styles from "./AuthInput.module.css";
 
-const AuthInput = ({ type = "password" }: { type: "password" | "text" }) => {
-  const [inputValue, setInputValue] = useState("");
-  const [isError, setIsError] = useState(false);
-  const [typeValue, setTypeValue] = useState("password");
+interface AuthInputProps {
+  type: "email" | "password";
+  register: UseFormRegister<FormInput>;
+  errors: FieldErrors<FormInput>;
+  isSubmit: boolean;
+}
 
-  const handleInputBlur = () => {
-    setIsError(!inputValue);
-  };
+const ERROR_MESSAGE = {
+  email: {
+    check: "이메일을 확인해 주세요.",
+    input: "이메일을 입력해 주세요.",
+    correct: "올바른 이메일 주소가 아닙니다.",
+  },
+  password: {
+    check: "비밀번호를 확인해 주세요.",
+    input: "비밀번호를 입력해 주세요.",
+  },
+};
+
+const AuthInput = ({ type = "email", register, errors, isSubmit }: AuthInputProps) => {
+  const [isEyeIcon, setIsEyeIcon] = useState(false);
 
   const handleEyeIconClick = () => {
-    if (typeValue === "password") {
-      setTypeValue("string");
-    } else {
-      setTypeValue("password");
-    }
+    setIsEyeIcon(!isEyeIcon);
   };
 
   return (
     <>
-      <div className={styles["input-box"]}>
-        <input
-          className={`${styles.input} ${isError && styles.error}`}
-          type={type === "password" ? typeValue : type}
-          value={inputValue}
-          placeholder="내용 입력"
-          onChange={(e) => {
-            setInputValue(e.target.value);
-          }}
-          onBlur={handleInputBlur}
-        ></input>
-        {type === "password" && (
+      {type === "email" && (
+        <div className={styles["input-box"]}>
+          <label className={styles.label} htmlFor="email">
+            이메일
+          </label>
+          <input
+            className={styles.input}
+            {...register("email", {
+              required: true,
+              pattern: EMAIL_REGEX,
+            })}
+            id="email"
+            name="email"
+            type={type}
+            placeholder={ERROR_MESSAGE.email.input}
+          />
+          {isSubmit ? (
+            <p className={styles["error-message"]}>{ERROR_MESSAGE.email.check}</p>
+          ) : (
+            <>
+              {errors?.email?.type === "required" && (
+                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.input}</p>
+              )}
+              {errors?.email?.type === "pattern" && (
+                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.correct}</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {type === "password" && (
+        <div className={styles["passwordInput-container"]}>
+          <div className={styles["input-box"]}>
+            <label className={styles.label} htmlFor="password">
+              비밀번호
+            </label>
+            <input
+              className={styles.input}
+              placeholder={ERROR_MESSAGE.password.input}
+              {...register("password", { required: true })}
+              id="password"
+              name="password"
+              type={isEyeIcon ? "text" : "password"}
+            />
+            {isSubmit ? (
+              <p className={styles["error-message"]}>{ERROR_MESSAGE.password.check}</p>
+            ) : (
+              errors?.password?.type === "required" && (
+                <p className={styles["error-message"]}>{ERROR_MESSAGE.password.input}</p>
+              )
+            )}
+          </div>
           <Image
             className={styles["input-eye"]}
             width={16}
             height={16}
-            src={typeValue === "string" ? "./assets/eye-on.svg" : "./assets/eye-off.svg"}
+            src={isEyeIcon ? "./assets/eye-on.svg" : "./assets/eye-off.svg"}
             alt="비밀번호 가리기"
             onClick={handleEyeIconClick}
           />
-        )}
-      </div>
-      {isError && <p className={styles["error-message"]}>내용을 다시 작성해주세요</p>}
+        </div>
+      )}
     </>
   );
 };

--- a/components/AuthInput/index.tsx
+++ b/components/AuthInput/index.tsx
@@ -1,15 +1,17 @@
-import { UseFormRegister, FieldErrors } from "react-hook-form";
-import { EMAIL_REGEX } from "@/lib/utils";
+import { UseFormRegister, UseFormWatch, FieldErrors } from "react-hook-form";
+import { EMAIL_REGEX, PASSWORD_REGEX } from "@/lib/utils";
 import { useState } from "react";
 import { FormInput } from "@/lib/types";
+import { postCheckEmail } from "@/lib/api";
 import Image from "next/image";
 import styles from "./AuthInput.module.css";
 
 interface AuthInputProps {
-  type: "email" | "password";
+  type: "email" | "emailSignup" | "password" | "passwordSignup" | "passwordConfirm";
   register: UseFormRegister<FormInput>;
+  watch?: UseFormWatch<FormInput>;
   errors: FieldErrors<FormInput>;
-  isSubmit: boolean;
+  isSubmit?: boolean;
 }
 
 const ERROR_MESSAGE = {
@@ -17,23 +19,35 @@ const ERROR_MESSAGE = {
     check: "이메일을 확인해 주세요.",
     input: "이메일을 입력해 주세요.",
     correct: "올바른 이메일 주소가 아닙니다.",
+    duplication: "이미 사용 중인 이메일입니다.",
   },
   password: {
     check: "비밀번호를 확인해 주세요.",
     input: "비밀번호를 입력해 주세요.",
+    placeholder: "영문, 숫자를 조합해 8자 이상 입력해 주세요.",
+    vaild: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
+  },
+  passwordConfirm: {
+    placeholder: "비밀번호와 일치하는 값을 입력해 주세요.",
+    vaild: "비밀번호가 일치하지 않아요.",
   },
 };
 
-const AuthInput = ({ type = "email", register, errors, isSubmit }: AuthInputProps) => {
+const AuthInput = ({ type = "email", register, watch, errors, isSubmit }: AuthInputProps) => {
   const [isEyeIcon, setIsEyeIcon] = useState(false);
 
   const handleEyeIconClick = () => {
     setIsEyeIcon(!isEyeIcon);
   };
 
+  const checkEmail = async (email: string) => {
+    const result = await postCheckEmail(email);
+    return result.error ? false : true;
+  };
+
   return (
     <>
-      {type === "email" && (
+      {(type === "email" || type === "emailSignup") && (
         <div className={styles["input-box"]}>
           <label className={styles.label} htmlFor="email">
             이메일
@@ -43,49 +57,101 @@ const AuthInput = ({ type = "email", register, errors, isSubmit }: AuthInputProp
             {...register("email", {
               required: true,
               pattern: EMAIL_REGEX,
+              validate: async (value) => await checkEmail(value),
             })}
             id="email"
             name="email"
             type={type}
             placeholder={ERROR_MESSAGE.email.input}
           />
-          {isSubmit ? (
-            <p className={styles["error-message"]}>{ERROR_MESSAGE.email.check}</p>
-          ) : (
+          {type === "emailSignup" ? (
             <>
-              {errors?.email?.type === "required" && (
-                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.input}</p>
-              )}
               {errors?.email?.type === "pattern" && (
                 <p className={styles["error-message"]}>{ERROR_MESSAGE.email.correct}</p>
+              )}
+              {errors?.email?.type === "validate" && (
+                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.duplication}</p>
+              )}
+            </>
+          ) : (
+            <>
+              {isSubmit ? (
+                <p className={styles["error-message"]}>{ERROR_MESSAGE.email.check}</p>
+              ) : (
+                <>
+                  {errors?.email?.type === "required" && (
+                    <p className={styles["error-message"]}>{ERROR_MESSAGE.email.input}</p>
+                  )}
+                  {errors?.email?.type === "pattern" && (
+                    <p className={styles["error-message"]}>{ERROR_MESSAGE.email.correct}</p>
+                  )}
+                </>
               )}
             </>
           )}
         </div>
       )}
 
-      {type === "password" && (
+      {(type === "password" || type === "passwordSignup" || type === "passwordConfirm") && (
         <div className={styles["passwordInput-container"]}>
           <div className={styles["input-box"]}>
             <label className={styles.label} htmlFor="password">
               비밀번호
             </label>
-            <input
-              className={styles.input}
-              placeholder={ERROR_MESSAGE.password.input}
-              {...register("password", { required: true })}
-              id="password"
-              name="password"
-              type={isEyeIcon ? "text" : "password"}
-            />
-            {isSubmit ? (
-              <p className={styles["error-message"]}>{ERROR_MESSAGE.password.check}</p>
-            ) : (
-              errors?.password?.type === "required" && (
-                <p className={styles["error-message"]}>{ERROR_MESSAGE.password.input}</p>
-              )
+
+            {type === "password" && (
+              <>
+                <input
+                  className={styles.input}
+                  placeholder={ERROR_MESSAGE.password.input}
+                  {...register("password", { required: true })}
+                  id="password"
+                  name="password"
+                  type={isEyeIcon ? "text" : "password"}
+                />
+                {isSubmit ? (
+                  <p className={styles["error-message"]}>{ERROR_MESSAGE.password.check}</p>
+                ) : (
+                  errors?.password?.type === "required" && (
+                    <p className={styles["error-message"]}>{ERROR_MESSAGE.password.input}</p>
+                  )
+                )}
+              </>
+            )}
+
+            {type === "passwordSignup" && (
+              <>
+                <input
+                  className={styles.input}
+                  placeholder={ERROR_MESSAGE.password.placeholder}
+                  {...register("password", { minLength: 8, pattern: PASSWORD_REGEX })}
+                  id="password"
+                  name="password"
+                  type={isEyeIcon ? "text" : "password"}
+                />
+                {(errors?.password?.type === "minLength" || errors?.password?.type === "pattern") && (
+                  <p className={styles["error-message"]}>{ERROR_MESSAGE.password.vaild}</p>
+                )}
+              </>
+            )}
+
+            {type === "passwordConfirm" && (
+              <>
+                <input
+                  className={styles.input}
+                  placeholder={ERROR_MESSAGE["passwordConfirm"].placeholder}
+                  {...register("passwordConfirm", { validate: (value) => value === watch?.("password") })}
+                  id="passwordConfirm"
+                  name="passwordConfirm"
+                  type={isEyeIcon ? "text" : "password"}
+                />
+                {errors?.passwordConfirm?.type === "validate" && (
+                  <p className={styles["error-message"]}>{ERROR_MESSAGE["passwordConfirm"].vaild}</p>
+                )}
+              </>
             )}
           </div>
+
           <Image
             className={styles["input-eye"]}
             width={16}

--- a/components/Logo/Logo.module.css
+++ b/components/Logo/Logo.module.css
@@ -1,0 +1,5 @@
+.image-box {
+  position: relative;
+  width: 210px;
+  height: 38px;
+}

--- a/components/Logo/index.tsx
+++ b/components/Logo/index.tsx
@@ -1,0 +1,15 @@
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./Logo.module.css";
+
+const Logo = () => {
+  return (
+    <Link href="/">
+      <div className={styles["image-box"]}>
+        <Image fill src="/assets/logo.svg" alt="Linkbrary 로고" />
+      </div>
+    </Link>
+  );
+};
+
+export default Logo;

--- a/components/SocialLogin/SocialLogin.module.css
+++ b/components/SocialLogin/SocialLogin.module.css
@@ -1,0 +1,42 @@
+.SocialLogin {
+  margin-top: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: 1px solid var(--gray20, #ccd5e3);
+  background: var(--gray10, #e7effb);
+}
+
+.text {
+  font-size: 1.4rem;
+}
+
+.links {
+  display: flex;
+  gap: 16px;
+}
+
+.icon-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 9999px;
+}
+
+.icon-box.google {
+  background-color: var(--white);
+}
+
+.icon-box.kakao {
+  background-color: #f5e14b;
+}
+
+.image {
+  position: relative;
+  width: 22px;
+  height: 22px;
+}

--- a/components/SocialLogin/SocialLogin.module.css
+++ b/components/SocialLogin/SocialLogin.module.css
@@ -1,4 +1,4 @@
-.SocialLogin {
+.social-login {
   margin-top: 32px;
   display: flex;
   justify-content: space-between;

--- a/components/SocialLogin/index.tsx
+++ b/components/SocialLogin/index.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import Image from "next/image";
+import styles from "./SocialLogin.module.css";
+
+const SocialLogin = () => {
+  return (
+    <div className={styles.SocialLogin}>
+      <span className={styles.text}>소셜 로그인</span>
+      <div className={styles.links}>
+        <Link href="https://www.google.com">
+          <div className={`${styles["icon-box"]} ${styles.google}`}>
+            <div className={styles.image}>
+              <Image fill src="/assets/google.png" alt="구글 로그인" />
+            </div>
+          </div>
+        </Link>
+        <Link href="https://www.kakaocorp.com/page">
+          <div className={`${styles["icon-box"]} ${styles.kakao}`}>
+            <div className={styles.image}>
+              <Image fill src="/assets/kakao.svg" alt="카카오 로그인" />
+            </div>
+          </div>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default SocialLogin;

--- a/components/SocialLogin/index.tsx
+++ b/components/SocialLogin/index.tsx
@@ -1,9 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
-import { SocialLoginProps } from "@/lib/types";
 import styles from "./SocialLogin.module.css";
 
-const SocialLogin = ({ children }: SocialLoginProps) => {
+const SocialLogin = ({ children = "소셜 로그인" }: { children: string }) => {
   return (
     <div className={styles.SocialLogin}>
       <span className={styles.text}>{children}</span>

--- a/components/SocialLogin/index.tsx
+++ b/components/SocialLogin/index.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import Image from "next/image";
+import { SocialLoginProps } from "@/lib/types";
 import styles from "./SocialLogin.module.css";
 
-const SocialLogin = () => {
+const SocialLogin = ({ children }: SocialLoginProps) => {
   return (
     <div className={styles.SocialLogin}>
-      <span className={styles.text}>소셜 로그인</span>
+      <span className={styles.text}>{children}</span>
       <div className={styles.links}>
         <Link href="https://www.google.com">
           <div className={`${styles["icon-box"]} ${styles.google}`}>

--- a/components/SocialLogin/index.tsx
+++ b/components/SocialLogin/index.tsx
@@ -4,7 +4,7 @@ import styles from "./SocialLogin.module.css";
 
 const SocialLogin = ({ children = "소셜 로그인" }: { children: string }) => {
   return (
-    <div className={styles.SocialLogin}>
+    <div className={styles["social-login"]}>
       <span className={styles.text}>{children}</span>
       <div className={styles.links}>
         <Link href="https://www.google.com">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,24 @@
-import { Folder, FolderLink, SampleFolder, User } from "./types";
+import { Folder, FolderLink, SampleFolder, User, Token } from "./types";
 
 const API_BASE_URL = "https://bootcamp-api.codeit.kr/api";
+
+export const postSignin = async (email: string, password: string): Promise<{ data: Token }> => {
+  const response = await fetch(`${API_BASE_URL}/sign-in`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email: email,
+      password: password,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("데이터를 불러오는데 실패했습니다");
+  }
+  return await response.json();
+};
 
 export const getUser = async (): Promise<{ data: User[] }> => {
   const response = await fetch(`${API_BASE_URL}/users/1`);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,7 +15,7 @@ export const postSignin = async (email: string, password: string): Promise<{ dat
   });
 
   if (!response.ok) {
-    throw new Error("데이터를 불러오는데 실패했습니다");
+    throw new Error("로그인에 실패했습니다");
   }
   return await response.json();
 };
@@ -33,7 +33,7 @@ export const postSignup = async (email: string, password: string): Promise<{ dat
   });
 
   if (!response.ok) {
-    throw new Error("데이터를 불러오는데 실패했습니다");
+    throw new Error("회원가입에 실패했습니다");
   }
   return await response.json();
 };
@@ -55,7 +55,7 @@ export const postCheckEmail = async (email: string): Promise<{ data?: CheckEmail
 export const getUser = async (): Promise<{ data: User[] }> => {
   const response = await fetch(`${API_BASE_URL}/users/1`);
   if (!response.ok) {
-    throw new Error("데이터를 불러오는데 실패했습니다");
+    throw new Error("유저 데이터를 불러오는데 실패했습니다");
   }
   return await response.json();
 };
@@ -63,7 +63,7 @@ export const getUser = async (): Promise<{ data: User[] }> => {
 export const getFolder = async (): Promise<{ data: Folder[] }> => {
   const response = await fetch(`${API_BASE_URL}/users/1/folders`);
   if (!response.ok) {
-    throw new Error("데이터를 불러오는데 실패했습니다");
+    throw new Error("유저의 폴더를 불러오는데 실패했습니다");
   }
   return await response.json();
 };
@@ -71,7 +71,7 @@ export const getFolder = async (): Promise<{ data: Folder[] }> => {
 export const getSampleFolder = async (): Promise<{ folder: SampleFolder }> => {
   const response = await fetch(`${API_BASE_URL}/sample/folder`);
   if (!response.ok) {
-    throw new Error("데이터를 불러오는데 실패했습니다");
+    throw new Error("샘플 폴더를 불러오는데 실패했습니다");
   }
   return await response.json();
 };
@@ -85,7 +85,7 @@ export const getFolderLinks = async (folderId?: number): Promise<{ data: FolderL
   }
 
   if (!response.ok) {
-    throw new Error("데이터를 불러오는데 실패했습니다");
+    throw new Error("유저의 링크를 불러오는데 실패했습니다");
   }
   return await response.json();
 };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,4 @@
-import { Folder, FolderLink, SampleFolder, User, Token } from "./types";
+import { Folder, FolderLink, SampleFolder, User, Token, CheckEmail } from "./types";
 
 const API_BASE_URL = "https://bootcamp-api.codeit.kr/api";
 
@@ -9,14 +9,46 @@ export const postSignin = async (email: string, password: string): Promise<{ dat
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      email: email,
-      password: password,
+      email,
+      password,
     }),
   });
 
   if (!response.ok) {
     throw new Error("데이터를 불러오는데 실패했습니다");
   }
+  return await response.json();
+};
+
+export const postSignup = async (email: string, password: string): Promise<{ data: Token }> => {
+  const response = await fetch(`${API_BASE_URL}/sign-up`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      password,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("데이터를 불러오는데 실패했습니다");
+  }
+  return await response.json();
+};
+
+export const postCheckEmail = async (email: string): Promise<{ data?: CheckEmail; error?: CheckEmail }> => {
+  const response = await fetch(`${API_BASE_URL}/check-email`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+    }),
+  });
+
   return await response.json();
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from "react";
+
 export interface FolderLink {
   id: number;
   created_at: Date;
@@ -49,4 +51,18 @@ export interface SampleFolder {
   name: string;
   owner: Owner;
   links: SampleFolderLink[];
+}
+
+export interface Token {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface FormInput {
+  email: string;
+  password: string;
+}
+
+export interface AuthButtonProps {
+  children: ReactNode;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,8 +61,18 @@ export interface Token {
 export interface FormInput {
   email: string;
   password: string;
+  passwordConfirm: string;
 }
 
 export interface AuthButtonProps {
   children: ReactNode;
+}
+
+export interface SocialLoginProps {
+  children: ReactNode;
+}
+
+export interface CheckEmail {
+  isUsableNickname: boolean;
+  error: string;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -60,6 +60,7 @@ export interface Token {
 
 export interface FormInput {
   email: string;
+  emailSignup: string;
   password: string;
   passwordConfirm: string;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,3 @@
-import { ReactNode } from "react";
-
 export interface FolderLink {
   id: number;
   created_at: Date;
@@ -63,14 +61,6 @@ export interface FormInput {
   emailSignup: string;
   password: string;
   passwordConfirm: string;
-}
-
-export interface AuthButtonProps {
-  children: ReactNode;
-}
-
-export interface SocialLoginProps {
-  children: ReactNode;
 }
 
 export interface CheckEmail {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -38,3 +38,5 @@ export const afterTimeDate = (value: Date) => {
   }
   return `${diffYear} year${diff < YEAR * 2 ? "" : "s"} ago`;
 };
+
+export const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -40,3 +40,4 @@ export const afterTimeDate = (value: Date) => {
 };
 
 export const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+export const PASSWORD_REGEX = /^(?=.*[0-9])(?=.*[a-zA-Z]).*$/;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.6.7",
         "next": "14.1.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-hook-form": "^7.50.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -3287,6 +3288,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.50.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
+      "integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "axios": "^1.6.7",
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-hook-form": "^7.50.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/pages/folder.tsx
+++ b/pages/folder.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from "react";
+import { useState } from "react";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
 import AddLinkBar from "@/components/AddLinkBar";
@@ -19,7 +19,7 @@ export async function getStaticProps() {
     const resfolder = await getFolder();
     const resfolderLinks = await getFolderLinks();
     user = resUser.data[0];
-    folder = resfolder.data;
+    folder = resfolder.data[0];
     folderLinks = resfolderLinks.data;
   } catch {
     return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import { getUser } from "@/lib/api";
 import { User } from "@/lib/types";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
-import AuthInput from "@/components/AuthInput";
 import Link from "next/link";
 import styles from "@/styles/Home.module.css";
 
@@ -34,9 +33,8 @@ const Home = ({ user }: { user: User }) => {
         <nav className={styles.Links}>
           <Link href="/folder">폴더 페이지 바로가기</Link>
           <Link href="/share">공유 페이지 바로가기</Link>
+          <Link href="/signin">로그인 페이지 바로가기</Link>
         </nav>
-        <h1>로그인 회원가입 공용 컴포넌트</h1>
-        <AuthInput type="password" />
       </main>
       <Footer />
     </>

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -30,7 +30,6 @@ const Signin = () => {
       accessToken && router.push("/folder");
     } catch {
       setIsSubmit(true);
-      alert("알수없는 오류가 발생했습니다");
     }
   };
 

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -22,15 +22,15 @@ const Signin = () => {
 
   const onSubmit = async (data: FormInput) => {
     const { email, password } = data;
-    let result;
     try {
-      result = await postSignin(email, password);
+      const result = await postSignin(email, password);
       const accessToken = result.data.accessToken;
       localStorage.setItem("accessToken", accessToken);
 
-      result && router.push("/folder");
+      accessToken && router.push("/folder");
     } catch {
       setIsSubmit(true);
+      alert("알수없는 오류가 발생했습니다");
     }
   };
 

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -8,6 +8,7 @@ import Logo from "@/components/Logo";
 import AuthInput from "@/components/AuthInput";
 import AuthButton from "@/components/AuthButton";
 import styles from "@/styles/signin.module.css";
+import SocialLogin from "@/components/SocialLogin";
 
 const Signin = () => {
   const router = useRouter();
@@ -59,6 +60,7 @@ const Signin = () => {
         </div>
 
         <AuthButton>로그인</AuthButton>
+        <SocialLogin />
       </form>
     </article>
   );

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,0 +1,67 @@
+import { useForm } from "react-hook-form";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { postSignin } from "@/lib/api";
+import { FormInput } from "@/lib/types";
+import { useState, useEffect } from "react";
+import Logo from "@/components/Logo";
+import AuthInput from "@/components/AuthInput";
+import AuthButton from "@/components/AuthButton";
+import styles from "@/styles/signin.module.css";
+
+const Signin = () => {
+  const router = useRouter();
+  const [isSubmit, setIsSubmit] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormInput>({ mode: "onBlur" });
+
+  const onSubmit = async (data: FormInput) => {
+    const { email, password } = data;
+    let result;
+    try {
+      result = await postSignin(email, password);
+      const accessToken = result.data.accessToken;
+      localStorage.setItem("accessToken", accessToken);
+
+      result && router.push("/folder");
+    } catch {
+      setIsSubmit(true);
+    }
+  };
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      router.push("/folder");
+    }
+  }, [router]);
+
+  return (
+    <article className={styles["signin-page"]}>
+      <header className={styles.header}>
+        <Logo />
+        <div className={styles["sub-header"]}>
+          <span className={styles.content}>회원이 아니신가요?</span>
+          <Link href="/signup" className={styles["signup-link"]}>
+            회원 가입하기
+          </Link>
+        </div>
+      </header>
+
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className={styles["AuthInput-box"]}>
+          <AuthInput type="email" register={register} errors={errors} isSubmit={isSubmit} />
+          <AuthInput type="password" register={register} errors={errors} isSubmit={isSubmit} />
+        </div>
+
+        <AuthButton>로그인</AuthButton>
+      </form>
+    </article>
+  );
+};
+
+export default Signin;

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,22 +1,23 @@
 import { useForm } from "react-hook-form";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { postSignin } from "@/lib/api";
+import { postSignup } from "@/lib/api";
 import { FormInput } from "@/lib/types";
 import { useState, useEffect } from "react";
 import Logo from "@/components/Logo";
 import AuthInput from "@/components/AuthInput";
 import AuthButton from "@/components/AuthButton";
-import SocialLogin from "@/components/SocialLogin";
 import styles from "@/styles/signin.module.css";
+import SocialLogin from "@/components/SocialLogin";
 
-const Signin = () => {
+const SignUp = () => {
   const router = useRouter();
   const [isSubmit, setIsSubmit] = useState(false);
 
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<FormInput>({ mode: "onBlur" });
 
@@ -24,7 +25,7 @@ const Signin = () => {
     const { email, password } = data;
     let result;
     try {
-      result = await postSignin(email, password);
+      result = await postSignup(email, password);
       const accessToken = result.data.accessToken;
       localStorage.setItem("accessToken", accessToken);
 
@@ -46,24 +47,25 @@ const Signin = () => {
       <header className={styles.header}>
         <Logo />
         <div className={styles["sub-header"]}>
-          <span className={styles.content}>회원이 아니신가요?</span>
-          <Link href="/signup" className={styles["sign-link"]}>
-            회원 가입하기
+          <span className={styles.content}>이미 회원이신가요?</span>
+          <Link href="/signin" className={styles["sign-link"]}>
+            로그인 하기
           </Link>
         </div>
       </header>
 
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className={styles["AuthInput-box"]}>
-          <AuthInput type="email" register={register} errors={errors} isSubmit={isSubmit} />
-          <AuthInput type="password" register={register} errors={errors} isSubmit={isSubmit} />
+          <AuthInput type="emailSignup" register={register} errors={errors} isSubmit={isSubmit} />
+          <AuthInput type="passwordSignup" register={register} errors={errors} />
+          <AuthInput type="passwordConfirm" register={register} watch={watch} errors={errors} />
         </div>
 
-        <AuthButton>로그인</AuthButton>
-        <SocialLogin>소셜 로그인</SocialLogin>
+        <AuthButton>회원가입</AuthButton>
+        <SocialLogin>다른 방식으로 가입하기</SocialLogin>
       </form>
     </article>
   );
 };
 
-export default Signin;
+export default SignUp;

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -30,9 +30,10 @@ const SignUp = () => {
       const accessToken = result.data.accessToken;
       localStorage.setItem("accessToken", accessToken);
 
-      result && router.push("/folder");
+      accessToken && router.push("/folder");
     } catch {
       setIsSubmit(true);
+      alert("알수없는 오류가 발생했습니다");
     }
   };
 

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -33,7 +33,6 @@ const SignUp = () => {
       accessToken && router.push("/folder");
     } catch {
       setIsSubmit(true);
-      alert("알수없는 오류가 발생했습니다");
     }
   };
 

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -22,10 +22,11 @@ const SignUp = () => {
   } = useForm<FormInput>({ mode: "onBlur" });
 
   const onSubmit = async (data: FormInput) => {
-    const { email, password } = data;
+    console.log(data);
+    const { emailSignup, password } = data;
     let result;
     try {
-      result = await postSignup(email, password);
+      result = await postSignup(emailSignup, password);
       const accessToken = result.data.accessToken;
       localStorage.setItem("accessToken", accessToken);
 

--- a/styles/signin.module.css
+++ b/styles/signin.module.css
@@ -12,7 +12,7 @@
   font-size: 1.6rem;
 }
 
-.signup-link {
+.sign-link {
   color: var(--primary);
   margin-left: 8px;
 }

--- a/styles/signin.module.css
+++ b/styles/signin.module.css
@@ -1,0 +1,25 @@
+.signin-page {
+  height: 100vh;
+  background-color: var(--background);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.sub-header {
+  padding-top: 16px;
+  font-size: 1.6rem;
+}
+
+.signup-link {
+  color: var(--primary);
+  margin-left: 8px;
+}
+
+.AuthInput-box {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 30px 0;
+}


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [로그인 페이지] “회원 가입하기”를 클릭하면 ‘/signup’ 페이지로 이동하나요?
- [x] [로그인 페이지] 이메일 input에 placeholder는 “이메일을 입력해 주세요.”, 비밀번호 input에 placeholder는 “비밀번호를 입력해 주세요.”가 보이나요?
- [x] [로그인 페이지] 이메일 input에서 focus out 할 때, 값이 없을 경우 아래에 “이메일을 입력해주세요.” 에러 메세지가 보이나요?
- [x] [로그인 페이지] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 아래에 “올바른 이메일 주소가 아닙니다.” 에러 메세지가 보이나요?
- [x] [로그인 페이지] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] [로그인 페이지] 로그인 실패하는 경우, 이메일 input 아래에 “이메일을 확인해주세요.”, 비밀번호 input 아래에 “비밀번호를 확인해주세요.” 에러 메세지가 보이나요?
- [x] [로그인 페이지] 로그인 버튼 클릭 또는 Enter키 입력으로 로그인 실행 되나요?
- [x] [로그인 페이지] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받으면 “/folder”로 이동하나요?
- [x] [회원가입 페이지] “회원 가입하기”를 클릭하면 ‘/signin’ 페이지로 이동하나요?
- [x] [회원가입 페이지] 이메일 input에 placeholder는 “이메일을 입력해 주세요.”, 비밀번호 input에 placeholder는 “영문, 숫자를 조합해 8자 이상 입력해 주세요. ”비밀번호 확인 input에 placeholder는 “비밀번호와 일치하는 값을 입력해 주세요.”가 보이나요?
- [x] [회원가입 페이지] 이메일 input에서 focus out 할 때, 값이 없을 경우 “이메일을 입력해주세요.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 “올바른 이메일 주소가 아닙니다.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않아요.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 실행 되나요?
- [x] [회원가입 페이지] 이메일 중복 확인은 “/api/check-email” POST 요청해서 확인 할 수 있나요?
- [x] [회원가입 페이지] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?
- [x] [로그인, 회원가입 페이지 공통] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지나요?
- [x] [로그인, 회원가입 페이지 공통] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [로그인, 회원가입 페이지 공통] 소셜 로그인에 구글 아이콘 클릭시 ‘https://www.google.com’, 카카오 아이콘 클릭시 ‘https://www.kakaocorp.com/page’로 이동하나요?
- [x] [로그인, 회원가입 페이지 공통] 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장하나요?
- [x] [로그인, 회원가입 페이지 공통] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 ‘/folder’ 페이지로 이동하나요?


### 심화

- [x] 로그인, 회원가입 기능에 react-hook-form을 활용했나요?


## 주요 변경사항

- 로그인 / 회원가입 페이지 구현

## 배포
로그인 페이지
https://3-weekly-mission-is9e-git-part2-week14-haeyong9701.vercel.app/signin

회원가입 페이지
https://3-weekly-mission-is9e-git-part2-week14-haeyong9701.vercel.app/signup

## 스크린샷

![스크린샷 2024-03-03 오후 5 16 38](https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/72595163/82cf788a-9607-4b72-839b-2f96a97bfc84)

![스크린샷 2024-03-03 오후 6 00 27](https://github.com/codeit-bootcamp-frontend/3-Weekly-Mission/assets/72595163/cd06773e-39d0-4d02-86fd-18be74a05a67)


## 멘토에게

